### PR TITLE
fix: add release attr to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "lib": "lib",
     "test": "tests"
   },
+  "release": {
+    "branches": ["main"]
+  },
   "devDependencies": {
     "@babel/cli": "^7.12.16",
     "@babel/core": "^7.12.16",


### PR DESCRIPTION
- add `release` attribute to package.json to fix sematic release