### PR TITLE
fix: add publish config to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "release": {
     "branches": ["main"]
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@babel/cli": "^7.12.16",
     "@babel/core": "^7.12.16",


### PR DESCRIPTION
- add `publishConfig` with property `access` set to `public` for enabling release to the public.